### PR TITLE
Add missing version to maxscale

### DIFF
--- a/confs/libvirt.json
+++ b/confs/libvirt.json
@@ -110,7 +110,8 @@
     "hostname" : "maxscale",
     "box" : "centos_7_libvirt",
     "product" : {
-      "name" : "maxscale"
+      "name" : "maxscale",
+      "version": "latest"
     },
     "memory_size" : "1024"
   }


### PR DESCRIPTION
Use latest relesed version by default.