### PR TITLE
add nameserver 8.8.8.8 to all VMs

### DIFF
--- a/core/commands/up_command.rb
+++ b/core/commands/up_command.rb
@@ -175,6 +175,7 @@ class UpCommand < BaseCommand
   # @param nde[String] name of the node
   # @return [Boolean] whether we were successfull or not
   def configure(node)
+    run_command("vagrant ssh #{node} -- 'sudo sh -c \"echo nameserver 8.8.8.8 >> /etc/resolv.conf\"'")
     @network_configs[node] = get_node_network_config(node, @config, @env)
     solo_config = "#{node}-config.json"
     role_file = GenerateCommand.role_file_name(@config.path, node)

--- a/core/network.rb
+++ b/core/network.rb
@@ -325,6 +325,7 @@ def collectConfigurationNetworkInfo(configuration,node_one='')
     configurationNetworkInfo["#{node}_private_ip"] = Network.getIP(configPath)[0]["ip"].to_s
     configurationNetworkInfo["#{node}_whoami"] = $session.getSSH(configPath, COMMAND_WHOAMI)[0].chomp
     configurationNetworkInfo["#{node}_hostname"] = $session.getSSH(configPath, COMMAND_HOSTNAME)[0].chomp
+    ShellCommands.run_command_in_dir($out, "vagrant ssh #{node} -- 'sudo sh -c \"echo nameserver 8.8.8.4 >> /etc/resolv.conf\"'", configuration)
     if $session.ipv6
       provider = get_provider(configuration)
       command = ''


### PR DESCRIPTION
Some Vagrant boxes have a wrong DNS resolving configuration and VM can't access outside world. As a quick hack 'nameserver 8.8.8.8' is added to /etc/resolve.conf of all VMs