### PR TITLE
24771 stop the initialization of mdbci configuration if it was idle for 10 minutes

### DIFF
--- a/core/commands/up_command.rb
+++ b/core/commands/up_command.rb
@@ -170,7 +170,9 @@ Labels should be separated with commas and should not contain any whitespaces.
   def bring_up_machine(provider, logger, node = '')
     logger.info("Bringing up #{(node.empty? ? 'configuration ' : 'node ')} #{@specification}")
     vagrant_flags = generate_vagrant_run_flags(provider)
-    run_command_and_log("vagrant up #{vagrant_flags} --provider=#{provider} #{node}", true, {}, logger)
+    extra_timeout_flag = @box_manager.getBox(@config.box_names(node).first)['extra_vagrant_output'] == 'true'
+    run_command_and_log("vagrant up #{vagrant_flags} --provider=#{provider} #{node}", true, {}, logger,
+                        break_on_inactivity: true, extra_timeout: extra_timeout_flag)
   end
 
   # Provide information for the end-user where to find the required information

--- a/core/services/shell_commands.rb
+++ b/core/services/shell_commands.rb
@@ -66,7 +66,7 @@ module ShellCommands
       logger.error("The running command was inactive for #{command_inactivity_timeout / 60} minutes.")
       logger.error("The command is: '#{command}'.")
     end
-    return false unless command_was_inactive && break_on_inactivity
+    return false if !command_was_inactive || !break_on_inactivity
 
     logger.error("The command '#{command}' was terminated after timeout ending.") if show_notifications
     Process.kill('KILL', pid)

--- a/core/services/shell_commands.rb
+++ b/core/services/shell_commands.rb
@@ -37,16 +37,18 @@ module ShellCommands
   # @param stderr_text [String] string to save history of stderr stream
   # @return [Array<IO>, String, String] array of streams (or nil if stream has ended), stdout history, stderr history.
   def self.log_command_streams(logger, stdout, stderr, stdout_text, stderr_text)
+    result_stdout_text = stdout_text
+    result_stderr_text = stderr_text
     wait_streams = []
     wait_streams << read_stream(stdout) do |line|
       logger.info(line)
-      stdout_text += line
+      result_stdout_text += line
     end
     wait_streams << read_stream(stderr) do |line|
       logger.error(line)
-      stderr_text += line
+      result_stderr_text += line
     end
-    [wait_streams.compact, stdout_text, stderr_text]
+    [wait_streams.compact, result_stdout_text, result_stderr_text]
   end
 
   # Handle the command inactivity, log messages about it, kill command process if break_on_inactivity is true

--- a/core/services/shell_commands.rb
+++ b/core/services/shell_commands.rb
@@ -60,8 +60,8 @@ module ShellCommands
   # @param break_on_inactivity [Boolean] flag to terminate command execution when it is idle
   # @return [Boolean] true if command process was killed, otherwise - false
   # rubocop:disable Metrics/ParameterLists
-  def self.handle_inactivity(logger, show_notifications, command_inactivity_timeout, command,
-                             command_was_inactive, pid, break_on_inactivity)
+  def self.handle_command_process_inactivity(logger, show_notifications, command_inactivity_timeout, command,
+                                             command_was_inactive, pid, break_on_inactivity)
     if show_notifications
       logger.error("The running command was inactive for #{command_inactivity_timeout / 60} minutes.")
       logger.error("The command is: '#{command}'.")
@@ -101,8 +101,9 @@ module ShellCommands
 
         result = IO.select(alive_streams, nil, nil, command_inactivity_timeout)
         if result.nil?
-          command_killed = handle_inactivity(logger, show_notifications, command_inactivity_timeout, command,
-                                             command_was_inactive, wthr.pid, inactivity_options[:break_on_inactivity])
+          command_killed = handle_command_process_inactivity(logger, show_notifications, command_inactivity_timeout,
+                                                             command, command_was_inactive, wthr.pid,
+                                                             inactivity_options[:break_on_inactivity])
           break true if command_killed
 
           command_was_inactive = true


### PR DESCRIPTION
Depends on 24784-allow-mdbci-to-configure-the-virtual-machines-in-parallel