### PR TITLE
Mark MariaDB repositories for CentOS with `module_hotfixes` to ensure…

### DIFF
--- a/assets/chef-recipes/cookbooks/galera/templates/default/mdbci.galera.rhel.erb
+++ b/assets/chef-recipes/cookbooks/galera/templates/default/mdbci.galera.rhel.erb
@@ -3,3 +3,4 @@ name = maxscale
 baseurl=<%= node['galera']['repo'] %>/
 gpgkey=<%= node['galera']['repo_key'] %>
 gpgcheck=1
+module_hotfixes=true

--- a/assets/chef-recipes/cookbooks/mariadb/templates/default/mdbci.mariadb.rhel.erb
+++ b/assets/chef-recipes/cookbooks/mariadb/templates/default/mdbci.mariadb.rhel.erb
@@ -3,3 +3,4 @@ name = MariaDB
 baseurl = <%= node['mariadb']['repo'] %>
 gpgkey=<%= node['mariadb']['repo_key'] %>
 gpgcheck=1
+module_hotfixes=true


### PR DESCRIPTION
… that they will be used by DFN (fixes #26338)