### PR TITLE
Add the choose_instance_type method to TerraformGcpGenerator and use …

### DIFF
--- a/config/boxes/boxes_gcp.json
+++ b/config/boxes/boxes_gcp.json
@@ -3,75 +3,111 @@
     "provider": "gcp",
     "image": "debian-cloud/debian-9",
     "platform": "debian",
-    "platform_version": "stretch"
+    "platform_version": "stretch",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "debian_buster_gcp": {
     "provider": "gcp",
     "image": "debian-cloud/debian-10",
     "platform": "debian",
-    "platform_version": "buster"
+    "platform_version": "buster",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "centos_6_gcp": {
     "provider": "gcp",
     "image": "centos-cloud/centos-6",
     "platform": "centos",
-    "platform_version": "6"
+    "platform_version": "6",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "centos_7_gcp": {
     "provider": "gcp",
     "image": "centos-cloud/centos-7",
     "platform": "centos",
-    "platform_version": "7"
+    "platform_version": "7",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "centos_8_gcp": {
     "provider": "gcp",
     "image": "centos-cloud/centos-8",
     "platform": "centos",
-    "platform_version": "8"
+    "platform_version": "8",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "ubuntu_bionic_gcp": {
     "provider": "gcp",
     "image": "ubuntu-os-cloud/ubuntu-1804-lts",
     "platform": "ubuntu",
-    "platform_version": "bionic"
+    "platform_version": "bionic",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "ubuntu_xenial_gcp": {
     "provider": "gcp",
     "image": "ubuntu-os-cloud/ubuntu-1604-lts",
     "platform": "ubuntu",
-    "platform_version": "xenial"
+    "platform_version": "xenial",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "rhel_6_gcp": {
     "provider": "gcp",
     "image": "rhel-cloud/rhel-6",
     "platform": "rhel",
     "platform_version": "6",
-    "configure_subscription_manager": "true"
+    "configure_subscription_manager": "true",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "rhel_7_gcp": {
     "provider": "gcp",
     "image": "rhel-cloud/rhel-7",
     "platform": "rhel",
     "platform_version": "7",
-    "configure_subscription_manager": "true"
+    "configure_subscription_manager": "true",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "rhel_8_gcp": {
     "provider": "gcp",
     "image": "rhel-cloud/rhel-8",
     "platform": "rhel",
     "platform_version": "8",
-    "configure_subscription_manager": "true"
+    "configure_subscription_manager": "true",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "sles_12_gcp": {
     "provider": "gcp",
     "image": "suse-cloud/sles-12",
     "platform": "sles",
-    "platform_version": "12"
+    "platform_version": "12",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   },
   "sles_15_gcp": {
     "provider": "gcp",
     "image": "suse-cloud/sles-15",
     "platform": "sles",
-    "platform_version": "15"
+    "platform_version": "15",
+    "default_machine_type": "g1-small",
+    "default_cpu_count": "1",
+    "default_memory_size": "1024"
   }
 }

--- a/config/boxes/boxes_gcp.json
+++ b/config/boxes/boxes_gcp.json
@@ -2,56 +2,48 @@
   "debian_stretch_gcp": {
     "provider": "gcp",
     "image": "debian-cloud/debian-9",
-    "machine_type": "f1-micro",
     "platform": "debian",
     "platform_version": "stretch"
   },
   "debian_buster_gcp": {
     "provider": "gcp",
     "image": "debian-cloud/debian-10",
-    "machine_type": "f1-micro",
     "platform": "debian",
     "platform_version": "buster"
   },
   "centos_6_gcp": {
     "provider": "gcp",
     "image": "centos-cloud/centos-6",
-    "machine_type": "f1-micro",
     "platform": "centos",
     "platform_version": "6"
   },
   "centos_7_gcp": {
     "provider": "gcp",
     "image": "centos-cloud/centos-7",
-    "machine_type": "f1-micro",
     "platform": "centos",
     "platform_version": "7"
   },
   "centos_8_gcp": {
     "provider": "gcp",
     "image": "centos-cloud/centos-8",
-    "machine_type": "f1-micro",
     "platform": "centos",
     "platform_version": "8"
   },
   "ubuntu_bionic_gcp": {
     "provider": "gcp",
     "image": "ubuntu-os-cloud/ubuntu-1804-lts",
-    "machine_type": "f1-micro",
     "platform": "ubuntu",
     "platform_version": "bionic"
   },
   "ubuntu_xenial_gcp": {
     "provider": "gcp",
     "image": "ubuntu-os-cloud/ubuntu-1604-lts",
-    "machine_type": "f1-micro",
     "platform": "ubuntu",
     "platform_version": "xenial"
   },
   "rhel_6_gcp": {
     "provider": "gcp",
     "image": "rhel-cloud/rhel-6",
-    "machine_type": "f1-micro",
     "platform": "rhel",
     "platform_version": "6",
     "configure_subscription_manager": "true"
@@ -59,7 +51,6 @@
   "rhel_7_gcp": {
     "provider": "gcp",
     "image": "rhel-cloud/rhel-7",
-    "machine_type": "f1-micro",
     "platform": "rhel",
     "platform_version": "7",
     "configure_subscription_manager": "true"
@@ -67,7 +58,6 @@
   "rhel_8_gcp": {
     "provider": "gcp",
     "image": "rhel-cloud/rhel-8",
-    "machine_type": "f1-micro",
     "platform": "rhel",
     "platform_version": "8",
     "configure_subscription_manager": "true"
@@ -75,14 +65,12 @@
   "sles_12_gcp": {
     "provider": "gcp",
     "image": "suse-cloud/sles-12",
-    "machine_type": "f1-micro",
     "platform": "sles",
     "platform_version": "12"
   },
   "sles_15_gcp": {
     "provider": "gcp",
     "image": "suse-cloud/sles-15",
-    "machine_type": "f1-micro",
     "platform": "sles",
     "platform_version": "15"
   }

--- a/core/commands/partials/terraform_configuration_generator.rb
+++ b/core/commands/partials/terraform_configuration_generator.rb
@@ -159,7 +159,13 @@ class TerraformConfigurationGenerator < BaseCommand
   # @return [Hash] list of the node parameters.
   def make_node_params(node, box_params)
     symbolic_box_params = Hash[box_params.map { |k, v| [k.to_sym, v] }]
-    { name: node[0].to_s, host: node[1]['hostname'].to_s }.merge(symbolic_box_params)
+    {
+        name: node[0].to_s,
+        host: node[1]['hostname'].to_s,
+        machine_type: node[1]['machine_type']&.to_s,
+        memory_size: node[1]['memory_size']&.to_i,
+        cpu_count: node[1]['cpu_count']&.to_i
+    }.compact.merge(symbolic_box_params)
   end
 
   # Parse path to the products configurations directory from configuration of node.

--- a/core/commands/partials/terraform_configuration_generator.rb
+++ b/core/commands/partials/terraform_configuration_generator.rb
@@ -232,7 +232,7 @@ class TerraformConfigurationGenerator < BaseCommand
     when 'aws'
       Result.ok(TerraformAwsGenerator.new(@configuration_id, @aws_config, @ui, @configuration_path, @ssh_keys))
     when 'gcp'
-      Result.ok(TerraformGcpGenerator.new(@configuration_id, @gcp_config, @ui, @configuration_path, @ssh_keys))
+      Result.ok(TerraformGcpGenerator.new(@configuration_id, @gcp_config, @ui, @configuration_path, @ssh_keys, @env.gcp_service))
     when 'digitalocean'
       Result.ok(TerraformDigitaloceanGenerator.new(@configuration_id, @digitalocean_config, @ui, @configuration_path, @ssh_keys))
     else Result.error("Unknown provider #{@provider}")

--- a/core/commands/partials/terraform_gcp_generator.rb
+++ b/core/commands/partials/terraform_gcp_generator.rb
@@ -8,9 +8,6 @@ require_relative '../../services/terraform_service'
 
 # The class generates the Terraform infrastructure file for Google Cloud Platform provider
 class TerraformGcpGenerator
-  DEFAULT_CPU_COUNT = 1
-  DEFAULT_MEMORY_SIZE = 1024
-
   # Initializer.
   # @param configuration_id [String] configuration id
   # @param gcp_config [Hash] hash of Google Cloud Platform configuration
@@ -42,16 +39,20 @@ class TerraformGcpGenerator
     file.puts(file_header)
     file.puts(provider_resource)
     node_params.each do |node|
-      instance_params = generate_instance_params(node)
-      print_node_info(instance_params)
-      file.puts(instance_resources(instance_params))
+      instance_result = generate_instance_params(node).and_then do |instance_params|
+        print_node_info(instance_params)
+        file.puts(instance_resources(instance_params))
+        Result.ok('')
+      end
+      raise instance_result.error if instance_result.error?
     end
     file.puts(vpc_resources) unless use_existing_network?
-    file.close
   rescue StandardError => e
     Result.error(e.message)
   else
     Result.ok('')
+  ensure
+    file.close unless file.nil? || file.closed?
   end
 
   # Generate the instance name.
@@ -78,17 +79,49 @@ class TerraformGcpGenerator
 
   private
 
+  # Checks for the existence of a machine type in the list of machine types.
+  # @param machine_types_list [Array<Hash>] list of machine types in format { cpu, ram, type }
+  # @param machine_type [String] machine type name
+  # @return [Boolean] true if machine type is available.
+  def machine_type_available?(machine_types_list, machine_type)
+    !machine_types_list.detect { |type| type[:type] == machine_type }.nil?
+  end
+
+  # Selects the type of machine depending on the node parameters.
+  # @param machine_types_list [Array<Hash>] list of machine types in format { cpu, ram, type }
+  # @param node [Hash] node parameters
+  # @return [Result::Base] instance type name.
+  def choose_instance_type(machine_types_list, node)
+    if node[:machine_type].nil? && node[:cpu_count].nil? && node[:memory_size].nil?
+      if machine_type_available?(machine_types_list, node[:default_machine_type])
+        Result.ok(node[:default_machine_type])
+      else
+        cpu = node[:default_cpu_count].to_i
+        ram = node[:default_memory_size].to_i
+        instance_type_by_preferences(machine_types_list, cpu, ram)
+      end
+    elsif node[:machine_type].nil?
+      cpu = node[:cpu_count]&.to_i || node[:default_cpu_count].to_i
+      ram = node[:memory_size]&.to_i || node[:default_memory_size].to_i
+      instance_type_by_preferences(machine_types_list, cpu, ram)
+    elsif machine_type_available?(machine_types_list, node[:machine_type])
+      Result.ok(node[:machine_type])
+    else
+      Result.error("#{node[:machine_type]} machine type not available in current region")
+    end
+  end
+
   # Selects the type of machine depending on the parameters of the cpu and memory.
+  # @param machine_types_list [Array<Hash>] list of machine types in format { cpu, ram, type }
   # @param cpu [Number] the number of virtual CPUs that are available to the instance
   # @param ram [Number] the amount of physical memory available to the instance, defined in MB
-  # @return [String] instance type name.
-  def choose_instance_type(cpu, ram)
-    machine_types = @gcp_service.machine_types_list.sort_by{ |t| [t[:cpu], t[:ram]] }
-    type = machine_types.select do |machine_type|
-      (machine_type[:cpu] >= (cpu || DEFAULT_CPU_COUNT)) &&
-          (machine_type[:ram] >= (ram || DEFAULT_MEMORY_SIZE))
-    end.first || machine_types.last
-    type[:type]
+  # @return [Result::Base] instance type name.
+  def instance_type_by_preferences(machine_types_list, cpu, ram)
+    machine_types = machine_types_list.sort_by{ |t| [t[:cpu], t[:ram]] }
+    type = machine_types.select { |machine_type| (machine_type[:cpu] >= cpu) && (machine_type[:ram] >= ram) }.first
+    return Result.error('The type of machine that meets the specified parameters can not be found') if type.nil?
+
+    Result.ok(type[:type])
   end
 
   # Log the information about the main parameters of the node.
@@ -251,19 +284,21 @@ class TerraformGcpGenerator
 
   # Generate a instance params for the configuration file.
   # @param node_params [Hash] list of the node parameters
-  # @return [Hash] instance params
+  # @return [Result::Base] instance params
   def generate_instance_params(node_params)
     labels = @configuration_labels.merge(hostname: TerraformService.format_string(Socket.gethostname),
                                          username: TerraformService.format_string(@user),
                                          machinename: TerraformService.format_string(node_params[:name]))
-    node_params.merge(
+    node_params = node_params.merge(
         labels: labels,
         instance_name: self.class.generate_instance_name(@configuration_id, node_params[:name]),
         network: network_name,
         user: @user,
         is_own_vpc: use_existing_network?,
-        key_file: @private_key_file_path,
-        machine_type: choose_instance_type(node_params['cpu_count']&.to_i, node_params['memory_size']&.to_i)
+        key_file: @private_key_file_path
     )
+    choose_instance_type(@gcp_service.machine_types_list, node_params).and_then do |machine_type|
+      Result.ok(node_params.merge(machine_type: machine_type))
+    end
   end
 end

--- a/core/commands/partials/terraform_gcp_generator.rb
+++ b/core/commands/partials/terraform_gcp_generator.rb
@@ -296,7 +296,7 @@ class TerraformGcpGenerator
         instance_name: self.class.generate_instance_name(@configuration_id, node_params[:name]),
         network: network_name,
         user: @user,
-        is_own_vpc: use_existing_network?,
+        is_own_vpc: !use_existing_network?,
         key_file: @private_key_file_path
     )
     choose_instance_type(@gcp_service.machine_types_list, node_params).and_then do |machine_type|

--- a/core/commands/partials/terraform_gcp_generator.rb
+++ b/core/commands/partials/terraform_gcp_generator.rb
@@ -119,7 +119,8 @@ class TerraformGcpGenerator
   def instance_type_by_preferences(machine_types_list, cpu, ram)
     type = machine_types_list
                .sort_by{ |t| [t[:cpu], t[:ram]] }
-               .select { |machine_type| (machine_type[:cpu] >= cpu) && (machine_type[:ram] >= ram) }.first
+               .select { |machine_type| (machine_type[:cpu] >= cpu) && (machine_type[:ram] >= ram) }
+               .first
     return Result.error('The type of machine that meets the specified parameters can not be found') if type.nil?
 
     Result.ok(type[:type])

--- a/core/commands/partials/terraform_gcp_generator.rb
+++ b/core/commands/partials/terraform_gcp_generator.rb
@@ -117,8 +117,9 @@ class TerraformGcpGenerator
   # @param ram [Number] the amount of physical memory available to the instance, defined in MB
   # @return [Result::Base] instance type name.
   def instance_type_by_preferences(machine_types_list, cpu, ram)
-    machine_types = machine_types_list.sort_by{ |t| [t[:cpu], t[:ram]] }
-    type = machine_types.select { |machine_type| (machine_type[:cpu] >= cpu) && (machine_type[:ram] >= ram) }.first
+    type = machine_types_list
+               .sort_by{ |t| [t[:cpu], t[:ram]] }
+               .select { |machine_type| (machine_type[:cpu] >= cpu) && (machine_type[:ram] >= ram) }.first
     return Result.error('The type of machine that meets the specified parameters can not be found') if type.nil?
 
     Result.ok(type[:type])

--- a/core/commands/partials/terraform_gcp_generator.rb
+++ b/core/commands/partials/terraform_gcp_generator.rb
@@ -38,19 +38,20 @@ class TerraformGcpGenerator
     file = File.open(configuration_file_path, 'w')
     file.puts(file_header)
     file.puts(provider_resource)
+    file.puts(vpc_resources) unless use_existing_network?
+    result = Result.ok('')
     node_params.each do |node|
-      instance_result = generate_instance_params(node).and_then do |instance_params|
+       result = generate_instance_params(node).and_then do |instance_params|
         print_node_info(instance_params)
         file.puts(instance_resources(instance_params))
         Result.ok('')
       end
-      raise instance_result.error if instance_result.error?
+      break if result.error?
     end
-    file.puts(vpc_resources) unless use_existing_network?
   rescue StandardError => e
     Result.error(e.message)
   else
-    Result.ok('')
+    result
   ensure
     file.close unless file.nil? || file.closed?
   end

--- a/core/services/box_definitions.rb
+++ b/core/services/box_definitions.rb
@@ -88,7 +88,7 @@ class BoxDefinitions
 
   REQUIRED_KEYS = %w[provider platform platform_version].freeze
   AWS_KEYS = %w[ami user default_instance_type].freeze
-  GCP_KEYS = %w[image].freeze
+  GCP_KEYS = %w[image default_machine_type default_cpu_count default_memory_size].freeze
   DIGITALOCEAN_KEYS = %w[image size user].freeze
 
   # @param box_definition [Hash] check that provided box description contains required keys

--- a/core/services/box_definitions.rb
+++ b/core/services/box_definitions.rb
@@ -88,7 +88,7 @@ class BoxDefinitions
 
   REQUIRED_KEYS = %w[provider platform platform_version].freeze
   AWS_KEYS = %w[ami user default_instance_type].freeze
-  GCP_KEYS = %w[image machine_type].freeze
+  GCP_KEYS = %w[image].freeze
   DIGITALOCEAN_KEYS = %w[image size user].freeze
 
   # @param box_definition [Hash] check that provided box description contains required keys

--- a/core/services/gcp_service.rb
+++ b/core/services/gcp_service.rb
@@ -116,4 +116,16 @@ class GcpService
   rescue StandardError => e
     @logger.error(e.message)
   end
+
+  # Fetch machines types list for current zone.
+  # @return [Array<Hash>] instance types in format { ram, cpu, type }.
+  def machine_types_list
+    return [] unless configured?
+
+    @service.fetch_all do |token|
+      @service.list_machine_types(@gcp_config['project'], @gcp_config['zone'], page_token: token)
+    end.map do |machine_type|
+      { ram: machine_type.memory_mb, cpu: machine_type.guest_cpus, type: machine_type.name }
+    end
+  end
 end


### PR DESCRIPTION
…it to generate machine_type in the google cloud instance resource, remove machine_type fields from gcp boxes (refs #26410)