### PR TITLE
Generate MaxScale CI repository using release[:repo_url] instead of r…

### DIFF
--- a/core/commands/generate_repository_partials/maxscale_ci_parser.rb
+++ b/core/commands/generate_repository_partials/maxscale_ci_parser.rb
@@ -43,7 +43,7 @@ module MaxscaleCiParser
       append_url(%w[dists]),
       save_as_field(:platform_version),
       lambda do |release, _|
-        url = add_auth_to_url(release[:url], auth)
+        url = add_auth_to_url(release[:repo_url], auth)
         release[:repo] = "#{url} #{release[:platform_version]} main"
         release
       end


### PR DESCRIPTION
…elease[:url] (refs #27248)