### PR TITLE
Override box parameters using node configuration

### DIFF
--- a/core/commands/partials/terraform_configuration_generator.rb
+++ b/core/commands/partials/terraform_configuration_generator.rb
@@ -140,7 +140,6 @@ class TerraformConfigurationGenerator < BaseCommand
   # @param node [Array] information of the node from configuration file
   # @param box_params [Hash] information of the box parameters with symbolic keys
   # @return [Hash] list of the box parameters.
-
   def override_box_params(node, box_params)
     node_box_params = node[1]['box_parameters'].transform_keys(&:to_sym)
     box_params.merge(node_box_params)

--- a/core/commands/partials/terraform_configuration_generator.rb
+++ b/core/commands/partials/terraform_configuration_generator.rb
@@ -118,6 +118,9 @@ class TerraformConfigurationGenerator < BaseCommand
   # @return [Hash] list of the node parameters.
   def make_node_params(node, box_params)
     symbolic_box_params = box_params.transform_keys(&:to_sym)
+    if node[1].key?('box_parameters')
+      symbolic_box_params = override_box_params(node, symbolic_box_params)
+    end
     symbolic_box_params.merge(
       {
           name: node[0].to_s,
@@ -129,6 +132,18 @@ class TerraformConfigurationGenerator < BaseCommand
           attached_disk: need_attached_disk?(node)
       }
     )
+  end
+
+  # Override the box parameters with the values specified in the box_parameters section
+  # of the node configuration
+  #
+  # @param node [Array] information of the node from configuration file
+  # @param box_params [Hash] information of the box parameters with symbolic keys
+  # @return [Hash] list of the box parameters.
+
+  def override_box_params(node, box_params)
+    node_box_params = node[1]['box_parameters'].transform_keys(&:to_sym)
+    box_params.merge(node_box_params)
   end
 
   # Determines whether the current node needs to attach an additional disk

--- a/core/services/configuration_generator.rb
+++ b/core/services/configuration_generator.rb
@@ -151,6 +151,7 @@ class ConfigurationGenerator
     product_configs = {}
     recipe_names = []
     provider = node_params[:provider]
+    name = node_params[:name]
 
     if node_params[:configure_subscription_manager] == 'true'
       if @rhel_config.nil?

--- a/docs/detailed_topics/template_creation.md
+++ b/docs/detailed_topics/template_creation.md
@@ -32,11 +32,12 @@ Example:
     }
 }
 ```
-__Optional__ parameters are product, products, labels, cnf_template_path:
+__Optional__ parameters are product, products, labels, cnf_template_path, box_parameters:
 * product is a description of a single product. [Full list of available products](../all_products.md).
 * products is a description of many products. [Full list of available products](../all_products.md).
 * labels is a set of labels. Names groups of machines that could be brought up independently of other machines in the configuration file. A set of machines with the same labels will be created when calling `mdbci up` with `--labels` option.
 * cnf_template_path is the path to the configuration files to be passed to the machine. When installing a database you must also specify the name of the configuration file and the path to the folder where the file is stored. It is advised to use absolute path in `cnf_template_path` as the relative path is calculated from within the configuration directory.
+* box_parameters is a description of the selected box parameters that are being overridden for a single node (e.g. disable RHEL system registration setting `configure_subscription_manager` flag to 'false'). See [boxes configuration](../configuration_files.md#boxes).
 
 Also need to specify for the product:
 * name is product name. [Full list of available products](../all_products.md).
@@ -83,6 +84,17 @@ Example:
             "name": "mdbe_prestaging",
             "version": "10.2.40-13",
             "include_unsupported": true
+        }
+  },
+    "node4": {
+        "box": "rhel_8_libvirt",
+        "hostname": "host4",
+        "product": {
+            "name": "mariadb",
+            "version": "10.6.5"
+        },
+        "box_parameters": {
+            "configure_subscription_manager": "false"
         }
     }
 }


### PR DESCRIPTION
Added `box_parameters` property to node templates to override the box parameters for a single machine