### PR TITLE
Check CPU quotas in the defaut region first

### DIFF
--- a/core/commands/configure_command.rb
+++ b/core/commands/configure_command.rb
@@ -176,8 +176,10 @@ Use the following short product names to configure them:
                                        @configuration.dig('gcp', 'credentials_file')),
       'project' => read_topic('Please input name of the Google Cloud Platform project',
                               @configuration.dig('gcp', 'project')),
+      'default_region' => read_topic('Please input name of the Google Cloud Platform region that will be used by default',
+                              @configuration.dig('gcp', 'default_region')),
       'regions' => read_topic('Please input Google Cloud Platform regions with a space',
-                           @configuration.dig('gcp', 'regions').join(' ')).split(' '),
+                           @configuration.dig('gcp', 'regions')).split(' '),
       'use_existing_network' => false
     }
     return settings unless read_topic('Use existing network for Google Compute instances?', 'y').casecmp('y').zero?

--- a/docs/detailed_topics/gcp_regions_management.md
+++ b/docs/detailed_topics/gcp_regions_management.md
@@ -2,10 +2,13 @@
 
 ## Configuration file
 Currently supported regions are listed in `config.yaml` file in the `~/.config/mdbci`.
+If the set of machines to be created does not meet the CPU quota in the default region, MDBCI will select another one from the `regions`
+list
 
 ```yaml
 gcp:
   ...
+  default_region: # the region used when the CPU quota is met
   regions: # list of supported regions
   - us-central1
   - europe-west4

--- a/docs/detailed_topics/mdbci_configurations.md
+++ b/docs/detailed_topics/mdbci_configurations.md
@@ -38,6 +38,7 @@ mdbe:
 gcp:
   credentials_file: "/path/to/credentials/gcp/file/credentials.json"
   project: # project id
+  default_region: # the region used when the CPU quota is met
   regions: # list of supported regions
   - us-central1
   - europe-west4


### PR DESCRIPTION
If the set of machines to be launched meets the CPU quotas, the default region will be selected. Otherwise, MDBCI will select the least busy region from the supported list that meets the quota.