### PR TITLE
Add the additional disk size to the list of configurable node parameters

### DIFF
--- a/core/commands/partials/terraform_aws_generator.rb
+++ b/core/commands/partials/terraform_aws_generator.rb
@@ -277,7 +277,7 @@ class TerraformAwsGenerator
        ebs_block_device {
         delete_on_termination = true
         device_name = "/dev/sdh"
-        volume_size = 100
+        volume_size = <%= additional_disk_size %>
      }
      <% end %>
       <%= connection_block %>

--- a/core/commands/partials/terraform_gcp_generator.rb
+++ b/core/commands/partials/terraform_gcp_generator.rb
@@ -251,7 +251,7 @@ class TerraformGcpGenerator
     resource "google_compute_disk" "<%= name %>-disk" {
       name    = "<%= instance_name %>-disk"
       type    = "pd-standard"
-      size    = 100
+      size    = <%= additional_disk_size %>
     }
   <% end %>
 

--- a/docs/detailed_topics/adding_additional_disk.md
+++ b/docs/detailed_topics/adding_additional_disk.md
@@ -7,11 +7,12 @@ Specify the `attach_disk` parameter in the template file to do this:
   "build": {
     "hostname": "default",
     "box": "debian_bullseye_gcp",
-    "attach_disk": "true"
+    "attach_disk": "true",
+    "additional_disk_size": 200
   }
 }
 ```
 
-mdbci will connect additional disk with 100 GB memory on this machine.
+You can also specify `additional_disk_size` parameter to configure the size of the additional disk (in GB). The default disk size is 100 GB.
 - the disk will be available at `/dev/sdh` path on AWS machines
 - at `/dev/disk/by-id/google-data-disk-0` path on GCP machines

--- a/docs/detailed_topics/adding_additional_disk.md
+++ b/docs/detailed_topics/adding_additional_disk.md
@@ -13,6 +13,6 @@ Specify the `attach_disk` parameter in the template file to do this:
 }
 ```
 
-You can also specify `additional_disk_size` parameter to configure the size of the additional disk (in GB). The default disk size is 100 GB.
+You can also specify `additional_disk_size` parameter to configure the size of the additional disk (in GB) that will be connected to this machine by MDBCI. The default disk size is 100 GB.
 - the disk will be available at `/dev/sdh` path on AWS machines
 - at `/dev/disk/by-id/google-data-disk-0` path on GCP machines


### PR DESCRIPTION
The size of additional disk can be configured in the template file