### PR TITLE
Change the order of SLES deregistration commands (fixes #30824)

### DIFF
--- a/assets/chef-recipes/cookbooks/suse-connect/recipes/unsubscription.rb
+++ b/assets/chef-recipes/cookbooks/suse-connect/recipes/unsubscription.rb
@@ -4,11 +4,12 @@ if node[:platform_version].to_i == 15
     ignore_failure true
   end
 end
+execute 'Deregister and clean up a system' do
+  command 'registercloudguest --clean'
+  ignore_failure true
+end
 execute 'Clean up a system' do
   command 'SUSEConnect --cleanup'
   ignore_failure true
 end
-execute 'Clean up a system' do
-  command 'registercloudguest --clean'
-  ignore_failure true
-end
+


### PR DESCRIPTION
Deregister a system with 'registercloudguest --clean' command before removing credentials files