### PR TITLE
Open REST-API port for MaxScale

### DIFF
--- a/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
+++ b/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
@@ -32,7 +32,7 @@ when "suse"
 end
 
 # iptables rules
-[3306, 4006, 4008, 4009, 4016, 5306, 4442, 6444, 6603, 9092, 27017].each do |port|
+[3306, 4006, 4008, 4009, 4016, 5306, 4442, 6444, 6603, 8989, 9092, 27017].each do |port|
   execute "Open port #{port}" do
     command "iptables -I INPUT -p tcp -m tcp --dport #{port} -j ACCEPT"
     command "iptables -I INPUT -p tcp --dport #{port} -j ACCEPT -m state --state NEW"


### PR DESCRIPTION
Needed if the tests are to interact with MaxScale directly. Mapping the port onto another port breaks the parts of the test code that assume the REST-API is listening on port 8989.