### PR TITLE
Update call for Docker installation via system package manager for RHEL7

### DIFF
--- a/assets/chef-recipes/cookbooks/docker/libraries/docker_installation_package.rb
+++ b/assets/chef-recipes/cookbooks/docker/libraries/docker_installation_package.rb
@@ -3,6 +3,7 @@ module DockerCookbook
     # Resource properties
     resource_name :docker_installation_package
 
+    provides :docker_installation_package
     provides :docker_installation, platform: 'amazon'
 
     property :setup_docker_repo, [TrueClass, FalseClass], default: lazy { platform?('amazon') ? false : true }, desired_state: false


### PR DESCRIPTION
Calling custom resource via `resource_name` for new versions of Chef is not supported anymore