### PR TITLE
Add the registration proxy server availability check for SUSE systems

### DIFF
--- a/assets/chef-recipes/cookbooks/suse-connect/libraries/registration.rb
+++ b/assets/chef-recipes/cookbooks/suse-connect/libraries/registration.rb
@@ -1,8 +1,10 @@
+require 'yaml'
 
 class Chef
   class Recipe
     module RegistrationHelpers
       SUBSCRIPTION_CREDENTIALS_FILE = '/etc/zypp/credentials.d/SCCcredentials'
+      SUSE_CONNECT_CONFIG = '/etc/SUSEConnect'
       REGISTRATION_ENDPOINT = '/connect/systems'
 
       # Read SUSE credentials from the node
@@ -16,9 +18,18 @@ class Chef
           key, value = *line.chomp.split("=")
           credentials[key] = value
         end
-        return {} unless %w[username password].all? { |key| credentials.key?(key)}
+        credentials['url'] = read_registration_server_url
+        return {} if !%w[username password].all? { |key| credentials.key?(key)} || credentials['url'].nil?
 
         credentials
+      end
+
+      # Read the address of the registration server
+      def self.read_registration_server_url
+        return unless File.exist?(SUSE_CONNECT_CONFIG)
+
+        suse_config_params = YAML.load_file(SUSE_CONNECT_CONFIG)
+        suse_config_params['url']
       end
 
       # Generate registration command for the machine
@@ -27,29 +38,27 @@ class Chef
         if use_proxy?(suse_connect_parameters)
           # Copying configuration script from the registration proxy requires HTTP protocol
           http_proxy_url = suse_connect_parameters['registration_proxy_url'].sub('https://', 'http://')
-          return "curl #{URI.join(http_proxy_url, '/tools/rmt-client-setup')} --output rmt-client-setup; yes | sh rmt-client-setup #{suse_connect_parameters['registration_proxy_url']}; SUSEConnect -r #{suse_connect_parameters['key']} -e #{suse_connect_parameters['email']} --url #{suse_connect_parameters['registration_proxy_url']}"
+          return "curl #{URI.join(http_proxy_url, '/tools/rmt-client-setup')} --output rmt-client-setup;"\
+                 " yes | sh rmt-client-setup #{suse_connect_parameters['registration_proxy_url']};"\
+                 " SUSEConnect -r #{suse_connect_parameters['key']} -e #{suse_connect_parameters['email']} --url #{suse_connect_parameters['registration_proxy_url']}"
         end
 
         "SUSEConnect -r #{suse_connect_parameters['key']} -e #{suse_connect_parameters['email']} --url https://scc.suse.com"
       end
+
       # Generate deregistration command for the machine
       # @param credentials [Hash] machine credentials in format {'username' : String, 'password' : String }
       # @param registration_proxy_url [String] URL for SUSE Registration Proxy server
-      def self.deregister_node_command(suse_connect_parameters, credentials)
-        registration_url = use_proxy?(suse_connect_parameters) ? suse_connect_parameters['registration_proxy_url'] : 'https://scc.suse.com'
-        "curl -k -X DELETE -u #{credentials['username']}:#{credentials['password']} #{URI.join(registration_url, REGISTRATION_ENDPOINT)}"
+      def self.deregister_node_command(credentials)
+        "curl -k -X DELETE -u #{credentials['username']}:#{credentials['password']} #{URI.join(credentials['url'], REGISTRATION_ENDPOINT)}"
       end
 
-      def self.proxy_available?(registration_proxy_url)
-        cmd = Mixlib::ShellOut.new("curl -k #{registration_proxy_url} --connect-timeout 2")
+      def self.use_proxy?(suse_connect_parameters)
+        cmd = Mixlib::ShellOut.new(
+          "curl -k #{suse_connect_parameters['registration_proxy_url']} --connect-timeout 2"
+        )
         cmd.run_command
         !cmd.error?
-      end
-
-      # Check if the system can be registered via the Registration Proxy Server
-      # @param suse_connect_parameters [Hash] subscription parameters in format {'provider': String, 'email' : String, 'key' : String, 'registration_proxy_url' : String }
-      def self.use_proxy?(suse_connect_parameters)
-        suse_connect_parameters['provider'] == 'gcp' && proxy_available?(suse_connect_parameters['registration_proxy_url'])
       end
     end
   end

--- a/assets/chef-recipes/cookbooks/suse-connect/libraries/registration.rb
+++ b/assets/chef-recipes/cookbooks/suse-connect/libraries/registration.rb
@@ -46,6 +46,8 @@ class Chef
         !cmd.error?
       end
 
+      # Check if the system can be registered via the Registration Proxy Server
+      # @param suse_connect_parameters [Hash] subscription parameters in format {'provider': String, 'email' : String, 'key' : String, 'registration_proxy_url' : String }
       def self.use_proxy?(suse_connect_parameters)
         suse_connect_parameters['provider'] == 'gcp' && proxy_available?(suse_connect_parameters['registration_proxy_url'])
       end

--- a/assets/chef-recipes/cookbooks/suse-connect/libraries/registration.rb
+++ b/assets/chef-recipes/cookbooks/suse-connect/libraries/registration.rb
@@ -24,16 +24,30 @@ class Chef
       # Generate registration command for the machine
       # @param suse_connect_parameters [Hash] subscription parameters in format {'email' : String, 'key' : String, 'registration_proxy_url' : String }
       def self.register_node_command(suse_connect_parameters)
-        # Copying configuration script from the registration proxy requires HTTP protocol
-        http_proxy_url = suse_connect_parameters['registration_proxy_url'].sub('https://', 'http://')
-        "curl #{URI.join(http_proxy_url, '/tools/rmt-client-setup')} --output rmt-client-setup; yes | sh rmt-client-setup #{suse_connect_parameters['registration_proxy_url']}; SUSEConnect -r #{suse_connect_parameters['key']} -e #{suse_connect_parameters['email']} --url #{suse_connect_parameters['registration_proxy_url']}"
-      end
+        if use_proxy?(suse_connect_parameters)
+          # Copying configuration script from the registration proxy requires HTTP protocol
+          http_proxy_url = suse_connect_parameters['registration_proxy_url'].sub('https://', 'http://')
+          return "curl #{URI.join(http_proxy_url, '/tools/rmt-client-setup')} --output rmt-client-setup; yes | sh rmt-client-setup #{suse_connect_parameters['registration_proxy_url']}; SUSEConnect -r #{suse_connect_parameters['key']} -e #{suse_connect_parameters['email']} --url #{suse_connect_parameters['registration_proxy_url']}"
+        end
 
+        "SUSEConnect -r #{suse_connect_parameters['key']} -e #{suse_connect_parameters['email']} --url https://scc.suse.com"
+      end
       # Generate deregistration command for the machine
       # @param credentials [Hash] machine credentials in format {'username' : String, 'password' : String }
       # @param registration_proxy_url [String] URL for SUSE Registration Proxy server
-      def self.deregister_node_command(registration_proxy_url, credentials)
-        "curl -k -X DELETE -u #{credentials['username']}:#{credentials['password']} #{URI.join(registration_proxy_url, REGISTRATION_ENDPOINT)}"
+      def self.deregister_node_command(suse_connect_parameters, credentials)
+        registration_url = use_proxy?(suse_connect_parameters) ? suse_connect_parameters['registration_proxy_url'] : 'https://scc.suse.com'
+        "curl -k -X DELETE -u #{credentials['username']}:#{credentials['password']} #{URI.join(registration_url, REGISTRATION_ENDPOINT)}"
+      end
+
+      def self.proxy_available?(registration_proxy_url)
+        cmd = Mixlib::ShellOut.new("curl -k #{registration_proxy_url} --connect-timeout 2")
+        cmd.run_command
+        !cmd.error?
+      end
+
+      def self.use_proxy?(suse_connect_parameters)
+        suse_connect_parameters['provider'] == 'gcp' && proxy_available?(suse_connect_parameters['registration_proxy_url'])
       end
     end
   end

--- a/assets/chef-recipes/cookbooks/suse-connect/recipes/default.rb
+++ b/assets/chef-recipes/cookbooks/suse-connect/recipes/default.rb
@@ -1,3 +1,5 @@
+SUSE_CUSTOMER_CENTER_URL = 'https://scc.suse.com'
+
 package 'SUSEConnect' do
   action :install
   ignore_failure true
@@ -14,14 +16,9 @@ execute 'Deregister the system if it has an old subscription' do
   not_if { node.run_state[:old_suse_credentials].empty? }
   command lazy {
     RegistrationHelpers.deregister_node_command(
-      node['suse-connect']['registration_proxy_url'],
+      node['suse-connect'],
       node.run_state[:old_suse_credentials])
   }
-  ignore_failure true
-end
-
-execute 'Deregister and clean up a system' do
-  command 'registercloudguest --clean'
   ignore_failure true
 end
 

--- a/assets/chef-recipes/cookbooks/suse-connect/recipes/default.rb
+++ b/assets/chef-recipes/cookbooks/suse-connect/recipes/default.rb
@@ -14,7 +14,6 @@ execute 'Deregister the system if it has an old subscription' do
   not_if { node.run_state[:old_suse_credentials].empty? }
   command lazy {
     RegistrationHelpers.deregister_node_command(
-      node['suse-connect'],
       node.run_state[:old_suse_credentials])
   }
   ignore_failure true

--- a/assets/chef-recipes/cookbooks/suse-connect/recipes/default.rb
+++ b/assets/chef-recipes/cookbooks/suse-connect/recipes/default.rb
@@ -1,5 +1,3 @@
-SUSE_CUSTOMER_CENTER_URL = 'https://scc.suse.com'
-
 package 'SUSEConnect' do
   action :install
   ignore_failure true

--- a/assets/chef-recipes/cookbooks/suse-connect/recipes/unsubscription.rb
+++ b/assets/chef-recipes/cookbooks/suse-connect/recipes/unsubscription.rb
@@ -8,7 +8,6 @@ end
 execute 'Deregister the system' do
   not_if { node.run_state[:suse_credentials].empty? }
   command lazy { RegistrationHelpers.deregister_node_command(
-    node['suse-connect'],
     node.run_state[:suse_credentials])}
 end
 

--- a/assets/chef-recipes/cookbooks/suse-connect/recipes/unsubscription.rb
+++ b/assets/chef-recipes/cookbooks/suse-connect/recipes/unsubscription.rb
@@ -8,7 +8,7 @@ end
 execute 'Deregister the system' do
   not_if { node.run_state[:suse_credentials].empty? }
   command lazy { RegistrationHelpers.deregister_node_command(
-    node['suse-connect']['registration_proxy_url'],
+    node['suse-connect'],
     node.run_state[:suse_credentials])}
 end
 

--- a/core/commands/destroy_command.rb
+++ b/core/commands/destroy_command.rb
@@ -171,7 +171,8 @@ Labels should be separated with commas, do not contain any whitespaces.
         uninstall_products(configuration, network_settings_result.value, registry_result.value)
       end
     end
-    cleanup_leftover_subscriptions(configuration.provider, configuration_path)
+    cleanup_result = cleanup_leftover_subscriptions(configuration.provider, configuration_path)
+    @ui.error(cleanup_result.error) if cleanup_result.error?
     if configuration.docker_configuration?
       docker_cleaner = DockerSwarmCleaner.new(@env, @ui)
       docker_cleaner.destroy_stack(configuration)

--- a/core/commands/destroy_command.rb
+++ b/core/commands/destroy_command.rb
@@ -171,7 +171,7 @@ Labels should be separated with commas, do not contain any whitespaces.
         uninstall_products(configuration, network_settings_result.value, registry_result.value)
       end
     end
-    cleanup_result = cleanup_leftover_subscriptions(configuration.provider, configuration_path)
+    cleanup_result = cleanup_leftover_subscriptions(configuration_path)
     @ui.error(cleanup_result.error) if cleanup_result.error?
     if configuration.docker_configuration?
       docker_cleaner = DockerSwarmCleaner.new(@env, @ui)
@@ -200,7 +200,7 @@ Labels should be separated with commas, do not contain any whitespaces.
   end
 
   # Withdraw all subscriptions that were not removed by Chef
-  def cleanup_leftover_subscriptions(provider, configuration_path)
+  def cleanup_leftover_subscriptions(configuration_path)
     @ui.info('Cleaning up leftover systems subscriptions')
     registration_manager = RegistrationManager.new(@env.suse_config['registration_proxy_url'], configuration_path, @ui)
     registration_manager.cleanup_subscriptions

--- a/core/commands/destroy_command.rb
+++ b/core/commands/destroy_command.rb
@@ -202,7 +202,7 @@ Labels should be separated with commas, do not contain any whitespaces.
   # Withdraw all subscriptions that were not removed by Chef
   def cleanup_leftover_subscriptions(provider, configuration_path)
     @ui.info('Cleaning up leftover systems subscriptions')
-    registration_manager = RegistrationManager.new(@env.suse_config['registration_proxy_url'], configuration_path, provider, @ui)
+    registration_manager = RegistrationManager.new(@env.suse_config['registration_proxy_url'], configuration_path, @ui)
     registration_manager.cleanup_subscriptions
   end
 

--- a/core/commands/destroy_command.rb
+++ b/core/commands/destroy_command.rb
@@ -171,7 +171,7 @@ Labels should be separated with commas, do not contain any whitespaces.
         uninstall_products(configuration, network_settings_result.value, registry_result.value)
       end
     end
-    cleanup_leftover_subscriptions(configuration_path)
+    cleanup_leftover_subscriptions(configuration.provider, configuration_path)
     if configuration.docker_configuration?
       docker_cleaner = DockerSwarmCleaner.new(@env, @ui)
       docker_cleaner.destroy_stack(configuration)
@@ -199,9 +199,9 @@ Labels should be separated with commas, do not contain any whitespaces.
   end
 
   # Withdraw all subscriptions that were not removed by Chef
-  def cleanup_leftover_subscriptions(configuration_path)
+  def cleanup_leftover_subscriptions(provider, configuration_path)
     @ui.info('Cleaning up leftover systems subscriptions')
-    registration_manager = RegistrationManager.new(@env.suse_config['registration_proxy_url'], configuration_path, @ui)
+    registration_manager = RegistrationManager.new(@env.suse_config['registration_proxy_url'], configuration_path, provider, @ui)
     registration_manager.cleanup_subscriptions
   end
 

--- a/core/commands/partials/registration_manager.rb
+++ b/core/commands/partials/registration_manager.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+require 'json'
 require_relative '../../services/ssh_commands'
 require_relative '../../services/shell_commands'
 
@@ -6,23 +8,47 @@ class RegistrationManager
   SUSE_CREDENTIALS_FILE = '/etc/zypp/credentials.d/SCCcredentials'
   REGISTRATION_COOKBOOK_NAME = 'suse-connect'
   REGISTRATION_ENDPOINT = '/connect/systems'
-  SUBSCRIPTION_CONFIG_DIR = ".subscriptions"
-  CUSTOMER_CENTER_URL = 'https://scc.suse.com'
+  SUBSCRIPTION_CONFIG_DIR = '.subscriptions'
+  SUSE_CONNECT_CONFIG = '/etc/SUSEConnect'
 
   def initialize(registration_proxy_url, configuration_path, machines_provider, logger)
     @registration_proxy_url = registration_proxy_url
     @configuration_path = configuration_path
     @subscriptions_config = File.join(@configuration_path, SUBSCRIPTION_CONFIG_DIR)
     @logger = logger
-    @use_proxy = use_proxy?(machines_provider)
   end
 
   def copy_machine_credentials_to_server(machine)
+    credentials = read_machine_credentials(machine)
+    return credentials if credentials.error?
+
+    write_credentials_file(machine, credentials.value)
+  end
+
+  def read_registration_server_url(machine)
+    command = "sudo cat #{SUSE_CONNECT_CONFIG}"
+    result = SshCommands.execute_command_with_ssh(machine, command)
+    return if result.error?
+
+    connect_config = YAML.load(result.value)
+    connect_config['url']
+  end
+
+  def read_machine_credentials(machine)
     command = "sudo cat #{SUSE_CREDENTIALS_FILE}"
     result = SshCommands.execute_command_with_ssh(machine, command)
-    if result.success?
-      write_credentials_file(machine, result.value)
+    return Result.error('Cannot read credentials file from the machine') if result.error?
+
+    credentials = {}
+    result.value.split("\n").map do |line|
+      key, value = *line.chomp.split('=')
+      credentials[key] = value
     end
+    credentials['url'] = read_registration_server_url(machine)
+    if !%w[username password].all? { |key| credentials.key?(key)} || credentials['url'].nil?
+      return Result.error('Invalid system credentials files')
+    end
+    Result.ok(credentials)
   end
 
   # Create a file with subscription credentials on the server in the a configuration directory
@@ -30,9 +56,7 @@ class RegistrationManager
     return Result.error('No subscriptions directory found') unless Dir.exist?(@subscriptions_config)
 
     file_path = File.join(@subscriptions_config, generate_credentials_filename(machine))
-    File.open(file_path, 'w') do |file|
-      file.write(credentials)
-    end
+    File.write(file_path, JSON.pretty_generate(credentials))
   end
 
   def generate_credentials_filename(machine)
@@ -52,38 +76,21 @@ class RegistrationManager
   def cleanup_subscriptions
     return Result.error('No subscriptions directory found') unless Dir.exist?(@subscriptions_config)
 
-    Dir.each_child(@subscriptions_config) do |filename|
-      withdraw_subscription(File.join(@subscriptions_config, filename))
+    begin
+      Dir.each_child(@subscriptions_config) do |filename|
+        withdraw_subscription(File.join(@subscriptions_config, filename))
+      end
+      Result.ok('Unsubscribed successfully')
+    rescue StandardError => e
+      Result.error('Subscription configuration files are corrupted')
     end
   end
 
   # Remove SUSE subscription by credentials specified in the given file
   def withdraw_subscription(filename)
-    cred_file = File.open(filename)
-    credentials = {}
-    cred_file.readlines.map do |line|
-      key, value = *line.chomp.split("=")
-      credentials[key] = value
-    end
-    return unless %w[username password].all? { |key| credentials.key?(key)}
-
-    run_deregistration_command(credentials)
-  end
-
-  # Run request to deregister the system with the given credentials
-  def run_deregistration_command(credentials)
-    registration_server_address = @use_proxy ? @registration_proxy_url : CUSTOMER_CENTER_URL
-    command = "curl -k -X DELETE -u #{credentials['username']}:#{credentials['password']} #{URI.join(registration_server_address, REGISTRATION_ENDPOINT)}"
+    file = File.open(filename)
+    credentials = JSON.parse(file)
+    command = "curl -k -X DELETE -u #{credentials['username']}:#{credentials['password']} #{URI.join(credentials['url'], REGISTRATION_ENDPOINT)}"
     ShellCommands.run_command(@logger, command)
-  end
-
-  # Check if the system can be registered via the Registration Proxy Server
-  def use_proxy?(machines_provider)
-    machines_provider == 'gcp' && proxy_available?
-  end
-
-  def proxy_available?
-    result = ShellCommands.run_command(@logger, "curl -k #{@registration_proxy_url} --connect-timeout 2")
-    result[:value].success?
   end
 end

--- a/core/commands/partials/registration_manager.rb
+++ b/core/commands/partials/registration_manager.rb
@@ -60,7 +60,7 @@ class RegistrationManager
   end
 
   def generate_credentials_filename(machine)
-    "#{machine['network']}-#{Time.now.to_i}"
+    "#{machine['network']}-#{Time.now.to_i}.json"
   end
 
   # Check if SUSE subscription is used for the node
@@ -89,7 +89,7 @@ class RegistrationManager
   # Remove SUSE subscription by credentials specified in the given file
   def withdraw_subscription(filename)
     file = File.open(filename)
-    credentials = JSON.parse(file)
+    credentials = JSON.load(file)
     command = "curl -k -X DELETE -u #{credentials['username']}:#{credentials['password']} #{URI.join(credentials['url'], REGISTRATION_ENDPOINT)}"
     ShellCommands.run_command(@logger, command)
   end

--- a/core/commands/partials/registration_manager.rb
+++ b/core/commands/partials/registration_manager.rb
@@ -77,12 +77,12 @@ class RegistrationManager
     ShellCommands.run_command(@logger, command)
   end
 
+  # Check if the system can be registered via the Registration Proxy Server
   def use_proxy?(machines_provider)
     machines_provider == 'gcp' && proxy_available?
   end
 
   def proxy_available?
-    @logger.info(@logger)
     result = ShellCommands.run_command(@logger, "curl -k #{@registration_proxy_url} --connect-timeout 2")
     result[:value].success?
   end

--- a/core/commands/partials/registration_manager.rb
+++ b/core/commands/partials/registration_manager.rb
@@ -11,7 +11,7 @@ class RegistrationManager
   SUBSCRIPTION_CONFIG_DIR = '.subscriptions'
   SUSE_CONNECT_CONFIG = '/etc/SUSEConnect'
 
-  def initialize(registration_proxy_url, configuration_path, machines_provider, logger)
+  def initialize(registration_proxy_url, configuration_path, logger)
     @registration_proxy_url = registration_proxy_url
     @configuration_path = configuration_path
     @subscriptions_config = File.join(@configuration_path, SUBSCRIPTION_CONFIG_DIR)

--- a/core/commands/partials/terraform_configurator.rb
+++ b/core/commands/partials/terraform_configurator.rb
@@ -41,7 +41,7 @@ class TerraformConfigurator
     @machine_configurator = MachineConfigurator.new(@ui)
     @attempts = @env.attempts&.to_i || 5
     @recreate_nodes = @env.recreate
-    @registration_manager = RegistrationManager.new(@env.suse_config['registration_proxy_url'], @config.path, @ui)
+    @registration_manager = RegistrationManager.new(@env.suse_config['registration_proxy_url'], @config.path, @provider, @ui)
     NetworkSettings.from_file(config.network_settings_file).match(
         ok: ->(result) { @network_settings = result },
         error: ->(_result) { @network_settings = NetworkSettings.new }

--- a/core/commands/partials/terraform_configurator.rb
+++ b/core/commands/partials/terraform_configurator.rb
@@ -41,7 +41,7 @@ class TerraformConfigurator
     @machine_configurator = MachineConfigurator.new(@ui)
     @attempts = @env.attempts&.to_i || 5
     @recreate_nodes = @env.recreate
-    @registration_manager = RegistrationManager.new(@env.suse_config['registration_proxy_url'], @config.path, @provider, @ui)
+    @registration_manager = RegistrationManager.new(@env.suse_config['registration_proxy_url'], @config.path, @ui)
     NetworkSettings.from_file(config.network_settings_file).match(
         ok: ->(result) { @network_settings = result },
         error: ->(_result) { @network_settings = NetworkSettings.new }


### PR DESCRIPTION
Only GCP systems will be registered through Proxy and only when it is available (otherwise they will be registered to SUSE Customer Center directly)