### PR TITLE
Fix connector_odbc recipe

### DIFF
--- a/assets/chef-recipes/cookbooks/connector_odbc/recipes/default.rb
+++ b/assets/chef-recipes/cookbooks/connector_odbc/recipes/default.rb
@@ -25,6 +25,7 @@ bash 'install_odbc' do
   code <<-SCRIPT
     install -d /usr/lib64/
     install lib/mariadb/libmaodbc.so /usr/lib64/
+    install lib/mariadb/libmariadb.so.3 /usr/lib64/
     install -d /usr/lib64/mariadb/
     install -d /usr/lib64/mariadb/plugin/
     install lib/mariadb/plugin/auth_gssapi_client.so /usr/lib64/mariadb/plugin/


### PR DESCRIPTION
The libmariadb shared library must also be installed alongside the driver.