### PR TITLE
Add 'main/debug' component of MDBE repos for Ubuntu

### DIFF
--- a/assets/chef-recipes/cookbooks/mariadb/recipes/mdberepos.rb
+++ b/assets/chef-recipes/cookbooks/mariadb/recipes/mdberepos.rb
@@ -40,10 +40,14 @@ when 'debian', 'ubuntu'
     end
   else
     repo_uri, repo_distribution = node['mariadb']['repo'].split(/\s+/)
+    deb_components = node['mariadb']['deb_components'].dup
+    if node[:platform] == 'ubuntu' && !deb_components.include?('main/debug')
+      deb_components.append('main/debug')
+    end
     apt_repository repo_file_name do
       uri repo_uri
       distribution repo_distribution
-      components node['mariadb']['deb_components']
+      components deb_components
       keyserver 'keyserver.ubuntu.com'
       key node['mariadb']['repo_key']
       sensitive true
@@ -53,7 +57,7 @@ when 'debian', 'ubuntu'
       apt_repository "#{repo_file_name}_unsupported" do
         uri unsupported_repo_uri
         distribution repo_distribution
-        components node['mariadb']['deb_components']
+        components deb_components
         keyserver 'keyserver.ubuntu.com'
         key node['mariadb']['repo_key']
         sensitive true

--- a/assets/chef-recipes/cookbooks/mariadb/recipes/mdberepos.rb
+++ b/assets/chef-recipes/cookbooks/mariadb/recipes/mdberepos.rb
@@ -40,14 +40,10 @@ when 'debian', 'ubuntu'
     end
   else
     repo_uri, repo_distribution = node['mariadb']['repo'].split(/\s+/)
-    deb_components = node['mariadb']['deb_components'].dup
-    if node[:platform] == 'ubuntu' && !deb_components.include?('main/debug')
-      deb_components.append('main/debug')
-    end
     apt_repository repo_file_name do
       uri repo_uri
       distribution repo_distribution
-      components deb_components
+      components node['mariadb']['components']
       keyserver 'keyserver.ubuntu.com'
       key node['mariadb']['repo_key']
       sensitive true
@@ -57,7 +53,7 @@ when 'debian', 'ubuntu'
       apt_repository "#{repo_file_name}_unsupported" do
         uri unsupported_repo_uri
         distribution repo_distribution
-        components deb_components
+        components node['mariadb']['components']
         keyserver 'keyserver.ubuntu.com'
         key node['mariadb']['repo_key']
         sensitive true

--- a/core/commands/generate_repository_partials/mdbe_parser.rb
+++ b/core/commands/generate_repository_partials/mdbe_parser.rb
@@ -60,7 +60,7 @@ module MdbeParser
       baseurl, version, platform, platform_version, mdbe_private_key
     )
     repo_path = "#{repo_path} #{platform_version}" if deb_repo
-    {
+    release_info = {
       repo: repo_path,
       repo_key: key,
       platform: platform,
@@ -69,6 +69,13 @@ module MdbeParser
       version: version,
       architecture: architecture
     }
+    if deb_repo
+      release_info[:components] = ['main']
+    end
+    if platform == 'ubuntu'
+      release_info[:components].append('main/debug')
+    end
+    release_info
   end
 
   def self.parse_mdbe_repository(config, mdbe_private_key, link_name, product_name, deb_repo = false)


### PR DESCRIPTION
'mariadb-*-dbgsym' packages for Ubuntu are located in 'main/debug' component (unlike for Debian)