### PR TITLE
Update AWS SLES images

### DIFF
--- a/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
+++ b/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
@@ -72,7 +72,7 @@ when "rhel", "centos", "fedora"
       EOF
     end
   end
-  # service iptables restart
+# service iptables restart
 when "suse", "opensuse", nil # nil stands for SLES 15
   execute "Save iptables rules" do
     command "iptables-save > /etc/sysconfig/iptables"

--- a/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
+++ b/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
@@ -25,19 +25,8 @@ when "rhel", "fedora", "centos"
     end
   end
 when "suse"
-  if node[:platform_version].to_i == 15 && node.attributes['kernel']['machine'] == 'aarch64'
-    zypper_repository 'Add repository for SuSEfirewall2' do
-      action :add
-      gpgcheck false
-      baseurl 'https://download.opensuse.org/repositories/home:/frispete:/Tumbleweed/15.4/'
-    end
-  end
-  execute 'Update zypper cache' do
-    command 'zypper refresh'
-  end
-  execute "Install iptables and SuSEfirewall2" do
+  execute "Install iptables" do
     command "zypper install -y iptables"
-    command "zypper install -y SuSEfirewall2"
   end
 end
 

--- a/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
+++ b/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
@@ -25,6 +25,16 @@ when "rhel", "fedora", "centos"
     end
   end
 when "suse"
+  if node[:platform_version].to_i == 15 && node.attributes['kernel']['machine'] == 'aarch64'
+    zypper_repository 'Add repository for SuSEfirewall2' do
+      action :add
+      gpgcheck false
+      baseurl 'https://download.opensuse.org/repositories/home:/frispete:/Tumbleweed/15.4/'
+    end
+  end
+  execute 'Update zypper cache' do
+    command 'zypper refresh'
+  end
   execute "Install iptables and SuSEfirewall2" do
     command "zypper install -y iptables"
     command "zypper install -y SuSEfirewall2"
@@ -62,7 +72,7 @@ when "rhel", "centos", "fedora"
       EOF
     end
   end
-# service iptables restart
+  # service iptables restart
 when "suse", "opensuse", nil # nil stands for SLES 15
   execute "Save iptables rules" do
     command "iptables-save > /etc/sysconfig/iptables"

--- a/config/boxes/boxes_aarch64_aws.json
+++ b/config/boxes/boxes_aarch64_aws.json
@@ -146,7 +146,7 @@
   "aarch64_sles_15_aws": {
     "provider": "aws",
     "architecture": "aarch64",
-    "ami": "ami-01b29647f47846dc1",
+    "ami": "ami-033017e02e11906c7",
     "user": "ec2-user",
     "platform": "sles",
     "platform_version": "15",
@@ -154,6 +154,7 @@
     "default_machine_type": "c6g.xlarge",
     "default_cpu_count": "4",
     "default_memory_size": "8192",
+    "configure_suse_connect": "true",
     "supported_instance_types": ["t4g.nano","t4g.micro","t4g.small","t4g.medium","t4g.large","t4g.xlarge","t4g.2xlarge","c6g.medium","c6g.large","c6g.xlarge","c6g.2xlarge","c6g.4xlarge","c6g.8xlarge","c6g.12xlarge","c6g.16xlarge","c6g.metal","c6gd.medium","c6gd.large","c6gd.xlarge","c6gd.2xlarge","c6gd.4xlarge","c6gd.8xlarge","c6gd.12xlarge","c6gd.16xlarge","c6gd.metal","c6gn.medium","c6gn.large","c6gn.xlarge","c6gn.2xlarge","c6gn.4xlarge","c6gn.8xlarge","c6gn.12xlarge","c6gn.16xlarge","m6g.medium","m6g.large","m6g.xlarge","m6g.2xlarge","m6g.4xlarge","m6g.8xlarge","m6g.12xlarge","m6g.16xlarge","m6g.metal","m6gd.medium","m6gd.large","m6gd.xlarge","m6gd.2xlarge","m6gd.4xlarge","m6gd.8xlarge","m6gd.12xlarge","m6gd.16xlarge","m6gd.metal","r6g.medium","r6g.large","r6g.xlarge","r6g.2xlarge","r6g.4xlarge","r6g.8xlarge","r6g.12xlarge","r6g.16xlarge","r6g.metal","r6gd.medium","r6gd.large","r6gd.xlarge","r6gd.2xlarge","r6gd.4xlarge","r6gd.8xlarge","r6gd.12xlarge","r6gd.16xlarge","r6gd.metal","x2gd.medium","x2gd.large","x2gd.xlarge","x2gd.2xlarge","x2gd.4xlarge","x2gd.8xlarge","x2gd.12xlarge","x2gd.16xlarge","x2gd.metal"]
   },
   "aarch64_rocky_linux_8_aws" : {

--- a/config/boxes/boxes_amd64_aws.json
+++ b/config/boxes/boxes_amd64_aws.json
@@ -171,7 +171,7 @@
   "sles_12_aws" : {
     "provider": "aws",
     "architecture": "amd64",
-    "ami": "ami-0c007f7970588f55c",
+    "ami": "ami-099f228207b9b1bda",
     "user": "ec2-user",
     "default_machine_type": "t3.medium",
     "default_cpu_count": "2",


### PR DESCRIPTION
- Updated AMIs for SLES AWS boxes due to the end of support.
- Removed unused SuSEfirewall2 package installation.