### PR TITLE
Replace 'deb_components' key with 'components' for deb repositories

### DIFF
--- a/assets/chef-recipes/cookbooks/galera_ci/attributes/default.rb
+++ b/assets/chef-recipes/cookbooks/galera_ci/attributes/default.rb
@@ -1,1 +1,1 @@
-default['galera_ci']['deb_components'] = ['main']
+default['galera_ci']['components'] = ['main']

--- a/assets/chef-recipes/cookbooks/galera_ci/recipes/galera_repository.rb
+++ b/assets/chef-recipes/cookbooks/galera_ci/recipes/galera_repository.rb
@@ -12,7 +12,7 @@ when 'debian', 'ubuntu'
     uri repo_uri
     distribution repo_distribution
     keyserver 'keyserver.ubuntu.com'
-    components node['galera_ci']['deb_components']
+    components node['galera_ci']['components']
     key repo_key
     sensitive true
   end

--- a/assets/chef-recipes/cookbooks/mariadb/attributes/default.rb
+++ b/assets/chef-recipes/cookbooks/mariadb/attributes/default.rb
@@ -19,4 +19,4 @@ default["mariadb"]["cnf_template"] = nil
 default['mariadb']['repo_file_name'] = 'mariadb'
 
 # MariaDB components for Debian repo
-default['mariadb']['deb_components'] = ['main']
+default['mariadb']['components'] = ['main']


### PR DESCRIPTION
Unify attribute names of deb-repository components in the recipes