### PR TITLE
Replace maxscale-enterprise with maxscale-trial

### DIFF
--- a/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
+++ b/assets/chef-recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
@@ -93,8 +93,8 @@ if node[:platform_family] == "windows"
     action :install
   end
 else
-  if node['maxscale']['repo_file_name'].include?('enterprise')
-    maxscale_package = 'maxscale-enterprise'
+  if node['maxscale']['repo_file_name'].include?('trial')
+    maxscale_package = 'maxscale-trial'
   else
     maxscale_package = 'maxscale'
   end


### PR DESCRIPTION
The package name is now maxscale for all versions. There is a need to install a trial version so the check can be switched to that.